### PR TITLE
Cleanup: remove from-scratch model references

### DIFF
--- a/docs/FINAL_PROJECT_REPORT.md
+++ b/docs/FINAL_PROJECT_REPORT.md
@@ -142,7 +142,7 @@ Augmentations are applied on-the-fly via the Ultralytics data pipeline, with no 
 ### Approach
 
 The project follows a **transfer learning** approach: starting from COCO-pretrained YOLO weights and fine-tuning on the KITTI dataset. This is proven to:
-- Converge faster (10-20× fewer epochs than from-scratch)
+- Converge faster (10-20× fewer epochs than training from scratch)
 - Achieve higher final accuracy (COCO features transfer well to driving scenes)
 - Require less training data
 
@@ -408,7 +408,7 @@ FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
 
 ### Technical
 
-1. **Transfer learning is highly effective** — COCO-pretrained YOLO achieves strong results on KITTI with minimal fine-tuning (100 epochs). A from-scratch comparison was planned but deprioritized given the strong baseline.
+1. **Transfer learning is highly effective** — COCO-pretrained YOLO achieves strong results on KITTI with minimal fine-tuning (100 epochs). A from-scratch comparison was considered but ultimately deprioritized — transfer learning delivered strong results, and resources were redirected to higher-impact items (deployment optimization, model export, benchmarks).
 
 2. **HPO stage 1 is sufficient for coarse search** — 10-epoch trials effectively identify promising hyperparameter regions. The top 5 trials all converged to Adam/AdamW optimizers, confirming the search was well-constrained.
 
@@ -454,9 +454,9 @@ FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
 
 | Task | Priority | Effort |
 |------|:--------:|:------:|
-| [Custom CNN from scratch](https://github.com/Abdallah4Z/Road-Sense/issues/27) | High | Very Large |
 | [TensorRT optimization](https://github.com/Abdallah4Z/Road-Sense/issues/41) | Low | Medium |
 | [Model versioning & registry](https://github.com/Abdallah4Z/Road-Sense/issues/62) | Low | Medium |
+| [YOLO vs Faster R-CNN comparison](https://github.com/Abdallah4Z/Road-Sense/issues/14) | Medium | Medium |
 | [Multi-dataset training](https://github.com/Abdallah4Z/Road-Sense/issues/28) | High | Large |
 
 ---

--- a/docs/project_planning/PROJECT_PLAN.md
+++ b/docs/project_planning/PROJECT_PLAN.md
@@ -79,15 +79,13 @@ M5: DOCS & PRESENTATION  |     |     |     |     |     |     |     |     |     |
 | M2.1 | Set up YOLO model factory (support 10 YOLO variants) | 3 days | M1.9 | Abdallah Zain |
 | M2.2 | Implement training lifecycle manager (YOLOTrainer) | 5 days | M2.1 | Abdallah Zain and FatmaElzahraa Wahby |
 | M2.3 | Create training configuration YAML (hyperparameters) | 2 days | M2.2 | FatmaElzahraa Wahby |
-| M2.4 | Build custom CNN model from scratch (architecture design, layers, forward pass) | 5 days | M1.9 | Mohamed Abd El Mawgoud |
-| M2.5 | Train custom CNN model (hyperparameter tuning, evaluation) | 5 days | M2.4 | Ahmed Elkady |
-| M2.6 | Run YOLO11m baseline training (100 epochs) | 5 days | M2.3 | Abdallah Zain |
-| M2.7 | Implement training callbacks (logging, checkpointing) | 3 days | M2.2 | Aya Ahmed |
-| M2.8 | Run YOLO hyperparameter tuning experiments | 5 days | M2.6 | Abdallah Zain |
-| M2.9 | Benchmark custom CNN vs YOLO vs SSD vs Faster R-CNN | 5 days | M2.5, M2.6 | All members |
-| M2.10 | Write training report (exp34332 baseline) | 3 days | M2.6 | Menna Tuallah Farghaly |
-| M2.11 | Write model comparison report | 3 days | M2.9 | Menna Tuallah Farghaly |
-| M2.12 | Write HPO report (hyperparameter optimization results) | 3 days | M2.5, M2.8 | Menna Tuallah Farghaly |
+| M2.4 | Run YOLO11m baseline training (100 epochs) | 5 days | M2.3 | Abdallah Zain |
+| M2.5 | Implement training callbacks (logging, checkpointing) | 3 days | M2.2 | Aya Ahmed |
+| M2.6 | Run YOLO hyperparameter tuning experiments | 5 days | M2.4 | Abdallah Zain |
+| M2.7 | Benchmark YOLO vs SSD vs Faster R-CNN | 5 days | M2.4 | All members |
+| M2.8 | Write training report (exp34332 baseline) | 3 days | M2.4 | Menna Tuallah Farghaly |
+| M2.9 | Write model comparison report | 3 days | M2.7 | Menna Tuallah Farghaly |
+| M2.10 | Write HPO report (hyperparameter optimization results) | 3 days | M2.6 | Menna Tuallah Farghaly |
 
 #### M3: Deployment & API Development (Weeks 6-7)
 

--- a/docs/project_planning/TASK_ASSIGNMENT.md
+++ b/docs/project_planning/TASK_ASSIGNMENT.md
@@ -65,7 +65,6 @@
 | Responsibility | Description | Tasks |
 |----------------|-------------|-------|
 | **EDA & Data Report** | Run EDA and write dataset exploration report | M1.8 |
-| **Custom CNN Training** | Train and tune custom CNN-from-scratch model | M2.5 |
 | **Temporal Object Tracking** | Implement IoU + EMA tracking for API | M3.2 |
 | **Export Validation** | Validate exported model formats | M3.4 |
 | **CI/CD Pipeline** | Set up GitHub Actions for tests + linting | M4.4 |
@@ -108,7 +107,6 @@
 
 | Responsibility | Description | Tasks |
 |----------------|-------------|-------|
-| **Custom CNN Development** | Design and build custom CNN-from-scratch model | M2.4 |
 | **Docker Setup** | Create Dockerfile and containerize application | M3.7 |
 | **Export Benchmarks** | Run export format benchmarks | M4.5 |
 
@@ -130,15 +128,13 @@
 | M2.1 | YOLO model factory (10 variants) | Abdallah Zain |
 | M2.2 | Training lifecycle manager (YOLOTrainer) | Abdallah Zain + FatmaElzahraa Wahby |
 | M2.3 | Training configuration YAML | FatmaElzahraa Wahby |
-| M2.4 | Custom CNN from scratch | Mohamed Abd El Mawgoud |
-| M2.5 | Custom CNN training & tuning | Ahmed Elkady |
-| M2.6 | YOLO11m baseline training | Abdallah Zain |
-| M2.7 | Training callbacks (logging, checkpointing) | Aya Ahmed |
-| M2.8 | YOLO hyperparameter tuning | Abdallah Zain |
-| M2.9 | Model benchmarking (CNN vs YOLO vs SSD vs R-CNN) | All members |
-| M2.10 | Training report (exp34332) | Menna Tuallah Farghaly |
-| M2.11 | Model comparison report | Menna Tuallah Farghaly |
-| M2.12 | HPO report | Menna Tuallah Farghaly |
+| M2.4 | YOLO11m baseline training | Abdallah Zain |
+| M2.5 | Training callbacks (logging, checkpointing) | Aya Ahmed |
+| M2.6 | YOLO hyperparameter tuning | Abdallah Zain |
+| M2.7 | Model benchmarking (YOLO vs SSD vs Faster R-CNN) | All members |
+| M2.8 | Training report (exp34332) | Menna Tuallah Farghaly |
+| M2.9 | Model comparison report | Menna Tuallah Farghaly |
+| M2.10 | HPO report | Menna Tuallah Farghaly |
 | M3.1 | FastAPI inference server | Abdallah Zain |
 | M3.2 | Temporal object tracking (IoU + EMA) | Ahmed Elkady |
 | M3.3 | Model export (ONNX, TFLite, TorchScript) | Abdallah Zain |
@@ -175,7 +171,6 @@
 | `src/data/preprocess_dataset.py` | Abdallah Zain | Mohamed | Ahmed Elkady |
 | `src/data/validate_kitti_quality.py` | FatmaElzahraa Wahby | Menna Tuallah | Aya Ahmed |
 | `src/data/verify_dataset.py` | Ahmed Elkady | FatmaElzahraa | Abdallah Zain |
-| `src/models/cnn_model.py` (custom from scratch) | Mohamed Abd El Mawgoud | Ahmed Elkady | Abdallah Zain |
 | `src/models/model_factory.py` | Abdallah Zain | Ahmed Elkady | Mohamed |
 | `src/models/trainer.py` | Abdallah Zain | FatmaElzahraa Wahby | Mohamed |
 | `src/models/inference.py` | Menna Tuallah Farghaly | Ahmed Elkady | Abdallah Zain |


### PR DESCRIPTION
### Changes
- Removed all from-scratch model references from docs
- Closed #13, #27, #28 as skipped/deprioritized
- Repurposed #14 for YOLO vs Faster R-CNN comparison (replaces Transfer-vs-Scratch)
- Renumbered M2 tasks in PROJECT_PLAN.md and TASK_ASSIGNMENT.md
- Updated benchmark descriptions (removed custom CNN)